### PR TITLE
Hashmap for locked tokens

### DIFF
--- a/voting/src/state.rs
+++ b/voting/src/state.rs
@@ -27,10 +27,20 @@ pub struct State {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct TokenManager {
-    pub token_balance: Uint128,
-    // pub locked_tokens: HashMap<u64, Uint128>,
-    //todo map poll_id to weight voted, mainly to find the largest weight staked at withdrawal time
-    pub participated_polls: Vec<u64>, // todo set of polls for the voter
+    pub token_balance: Uint128, // total staked balance
+    pub locked_tokens: HashMap<u64, Uint128>, //maps poll_id to weight voted
+    pub participated_polls: Vec<u64>, // poll_id
+}
+
+impl TokenManager {
+    pub fn new() -> Self {
+        let balance = Uint128::zero();
+        TokenManager {
+            token_balance: balance,
+            locked_tokens: HashMap::new(),
+            participated_polls: Vec::new()
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/voting/src/state.rs
+++ b/voting/src/state.rs
@@ -5,7 +5,6 @@ use cosmwasm_storage::{
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
 
 static CONFIG_KEY: &[u8] = b"config";
 static POLL_KEY: &[u8] = b"polls";
@@ -19,24 +18,11 @@ pub struct State {
     pub staked_tokens: Uint128,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Default, Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct TokenManager {
     pub token_balance: Uint128, // total staked balance
-    pub locked_tokens: HashMap<u64, Uint128>, //maps poll_id to weight voted
+    pub locked_tokens: Vec<(u64, Uint128)>, //maps poll_id to weight voted
     pub participated_polls: Vec<u64>, // poll_id
-}
-
-impl TokenManager {
-    pub fn new() -> Self {
-        let token_balance = Uint128::zero();
-        let locked_tokens = HashMap::new();
-        let participated_polls = Vec::new();
-        TokenManager {
-            token_balance,
-            locked_tokens,
-            participated_polls,
-        }
-    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/voting/src/state.rs
+++ b/voting/src/state.rs
@@ -34,11 +34,13 @@ pub struct TokenManager {
 
 impl TokenManager {
     pub fn new() -> Self {
-        let balance = Uint128::zero();
+        let token_balance = Uint128::zero();
+        let locked_tokens = HashMap::new();
+        let participated_polls = Vec::new();
         TokenManager {
-            token_balance: balance,
-            locked_tokens: HashMap::new(),
-            participated_polls: Vec::new()
+            token_balance,
+            locked_tokens,
+            participated_polls,
         }
     }
 }
@@ -96,30 +98,6 @@ pub fn bank<S: Storage>(storage: &mut S) -> Bucket<S, TokenManager> {
 
 pub fn bank_read<S: Storage>(storage: &S) -> ReadonlyBucket<S, TokenManager> {
     bucket_read( BANK_KEY, storage)
-}
-
-pub fn poll_voters<S: Storage>(storage: &mut S) -> Bucket<S, Voter> {
-    bucket(POLL_VOTERS_KEY, storage)
-}
-
-pub fn poll_voters_read<S: Storage>(storage: &S) -> ReadonlyBucket<S, Voter> {
-    bucket_read( POLL_VOTERS_KEY, storage)
-}
-
-pub fn poll_voter_info<S: Storage>(storage: &mut S) -> Bucket<S, Voter> {
-    bucket(POLL_VOTER_INFO_KEY, storage)
-}
-
-pub fn poll_voter_info_read<S: Storage>(storage: &S) -> ReadonlyBucket<S, Voter> {
-    bucket_read( POLL_VOTER_INFO_KEY, storage)
-}
-
-pub fn locked_tokens<S: Storage>(storage: &mut S) -> Bucket<S, Uint128> {
-    bucket(LOCKED_TOKENS_KEY, storage)
-}
-
-pub fn locked_tokens_read<S: Storage>(storage: &S) -> ReadonlyBucket<S, Uint128> {
-    bucket_read( LOCKED_TOKENS_KEY, storage)
 }
 
 pub fn next_poll_id<S: Storage>(storage: &mut S) -> StdResult<u64> {

--- a/voting/src/state.rs
+++ b/voting/src/state.rs
@@ -1,21 +1,15 @@
 use cosmwasm_std::{CanonicalAddr, HumanAddr, Env, Storage, Uint128, StdResult};
 use cosmwasm_storage::{
     bucket, bucket_read, singleton, singleton_read, Bucket, ReadonlyBucket, ReadonlySingleton,
-    Singleton, ReadonlyPrefixedStorage, sequence, nextval, currval,
+    Singleton, ReadonlyPrefixedStorage
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 
 static CONFIG_KEY: &[u8] = b"config";
-static POLL_ID: &[u8] = b"poll_id";
 static POLL_KEY: &[u8] = b"polls";
-static POLL_VOTERS_KEY: &[u8] = b"poll_voters";
-static POLL_VOTER_INFO_KEY: &[u8] = b"poll_voter_info";
-static LOCKED_TOKENS_KEY: &[u8] = b"locked_tokens";
 static BANK_KEY: &[u8] = b"bank";
-pub const PREFIX_VOTERS: &[u8] = b"voters";
-pub const PREFIX_ALLOWANCES: &[u8] = b"allowances";
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct State {
@@ -99,14 +93,3 @@ pub fn bank<S: Storage>(storage: &mut S) -> Bucket<S, TokenManager> {
 pub fn bank_read<S: Storage>(storage: &S) -> ReadonlyBucket<S, TokenManager> {
     bucket_read( BANK_KEY, storage)
 }
-
-pub fn next_poll_id<S: Storage>(storage: &mut S) -> StdResult<u64> {
-    let mut seq = sequence(storage, POLL_ID);
-    nextval(&mut seq)
-}
-
-//todo currval for poll count if needed
-// pub fn curr_poll_id<S: Storage>(storage: &S) -> StdResult<u64> {
-//     let mut seq = singleton(storage, POLL_ID);
-//     currval(&mut seq)
-// }


### PR DESCRIPTION
---- tests::tests::fails_cast_vote_twice stdout ----
thread 'tests::tests::fails_cast_vote_twice' panicked at 'internal error: entered unreachable code', /Users/taariq/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-json-wasm-0.2.1/src/ser/mod.rs:376:9
stack backtrace:
   0: backtrace::backtrace::libunwind::trace
             at /Users/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.44/src/backtrace/libunwind.rs:86
   1: backtrace::backtrace::trace_unsynchronized
             at /Users/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.44/src/backtrace/mod.rs:66
   2: std::sys_common::backtrace::_print_fmt
             at src/libstd/sys_common/backtrace.rs:78
   3: <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt
             at src/libstd/sys_common/backtrace.rs:59
   4: core::fmt::write
             at src/libcore/fmt/mod.rs:1063
   5: std::io::Write::write_fmt
             at /rustc/8d69840ab92ea7f4d323420088dd8c9775f180cd/src/libstd/io/mod.rs:1426
   6: std::io::impls::<impl std::io::Write for alloc::boxed::Box<W>>::write_fmt
             at src/libstd/io/impls.rs:156
   7: std::sys_common::backtrace::_print
             at src/libstd/sys_common/backtrace.rs:62
   8: std::sys_common::backtrace::print
             at src/libstd/sys_common/backtrace.rs:49
   9: std::panicking::default_hook::{{closure}}
             at src/libstd/panicking.rs:204
  10: std::panicking::default_hook
             at src/libstd/panicking.rs:221
  11: std::panicking::rust_panic_with_hook
             at src/libstd/panicking.rs:470
  12: std::panicking::begin_panic
  13: <&mut serde_json_wasm::ser::Serializer as serde::ser::Serializer>::serialize_map
             at /Users/taariq/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-json-wasm-0.2.1/src/ser/mod.rs:376
  14: serde::ser::Serializer::collect_map
             at /Users/taariq/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-1.0.103/src/ser/mod.rs:1320
  15: serde::ser::impls::<impl serde::ser::Serialize for std::collections::hash::map::HashMap<K,V,H>>::serialize
             at /Users/taariq/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-1.0.103/src/ser/impls.rs:364
  16: <serde_json_wasm::ser::struct_::SerializeStruct as serde::ser::SerializeStruct>::serialize_field
             at /Users/taariq/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-json-wasm-0.2.1/src/ser/struct_.rs:34
  17: cw_voting::state::_IMPL_SERIALIZE_FOR_TokenManager::<impl serde::ser::Serialize for cw_voting::state::TokenManager>::serialize
             at src/state.rs:22
  18: serde_json_wasm::ser::to_vec
             at /Users/taariq/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-json-wasm-0.2.1/src/ser/mod.rs:422
  19: cosmwasm_std::serde::to_vec
             at /Users/taariq/.cargo/registry/src/github.com-1ecc6299db9ec823/cosmwasm-std-0.8.0/src/serde.rs:23
  20: cosmwasm_storage::bucket::Bucket<S,T>::save
             at /Users/taariq/.cargo/registry/src/github.com-1ecc6299db9ec823/cosmwasm-storage-0.8.0/src/bucket.rs:65
  21: cw_voting::contract::stake_voting_tokens
             at src/contract.rs:104
  22: cw_voting::contract::handle
             at src/contract.rs:59
  23: cw_voting::tests::tests::fails_cast_vote_twice
             at src/tests.rs:805
  24: cw_voting::tests::tests::fails_cast_vote_twice::{{closure}}
             at src/tests.rs:782
  25: core::ops::function::FnOnce::call_once
             at /rustc/8d69840ab92ea7f4d323420088dd8c9775f180cd/src/libcore/ops/function.rs:232
  26: <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once
             at /rustc/8d69840ab92ea7f4d323420088dd8c9775f180cd/src/liballoc/boxed.rs:1017
  27: __rust_maybe_catch_panic
             at src/libpanic_unwind/lib.rs:86
  28: std::panicking::try
             at /rustc/8d69840ab92ea7f4d323420088dd8c9775f180cd/src/libstd/panicking.rs:281
  29: std::panic::catch_unwind
             at /rustc/8d69840ab92ea7f4d323420088dd8c9775f180cd/src/libstd/panic.rs:394
  30: test::run_test_in_process
             at src/libtest/lib.rs:542
  31: test::run_test::run_test_inner::{{closure}}
             at src/libtest/lib.rs:451
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.